### PR TITLE
Update the code   the section Configuration

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -342,7 +342,7 @@ directory and the ``controllers.json`` file if you need to use different paths:
     stimulus:
         # the default values
         controller_paths:
-            - %kernel.project_dir%/assets/controllers
+            - '%kernel.project_dir%/assets/controllers'
         controllers_json: '%kernel.project_dir%/assets/controllers.json'
 
 .. _manual-installation:


### PR DESCRIPTION
This PR to fix the code in the section [Configuration](https://symfony.com/bundles/StimulusBundle/current/index.html#configuration) because when you copy/paste the code from it, you get the following error:

<img width="1253" alt="image" src="https://github.com/symfony/stimulus-bundle/assets/19323431/9bef1fa1-69c3-414f-9679-8edf5eeaa7bc">
