### PR TITLE
Update StimulusLoaderJavaScriptCompiler.php

### DIFF
--- a/src/AssetMapper/StimulusLoaderJavaScriptCompiler.php
+++ b/src/AssetMapper/StimulusLoaderJavaScriptCompiler.php
@@ -62,7 +62,7 @@ class StimulusLoaderJavaScriptCompiler implements AssetCompilerInterface
              * and mark it as a "content" dependency so that this file's contents
              * will be recalculated when the contents of any controller changes.
              */
-            if (class_exists(AssetDependency::class)) {
+            if (class_exists(AssetDependency::class, false)) {
                 // Backwards compatibility with Symfony 6.3
                 $asset->addDependency(new AssetDependency(
                     $mappedControllerAsset->asset,


### PR DESCRIPTION
don't fail if class does not exist. I think this will prevent the error when using in 6.4.

Alternatively, I guess we could explicitly look for the class name as a string?

