### PR TITLE
fix missing }, reformat

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -241,7 +241,10 @@ And with outlets:
 
 .. code-block:: html+twig
 
-    <div {{ stimulus_controller('chart', { 'name': 'Likes', 'data': [1, 2, 3, 4] }, { 'loading': 'spinner' }, { 'other': '.target' ) }}>
+    <div {{ stimulus_controller('chart',
+            { 'name': 'Likes', 'data': [1, 2, 3, 4] }, 
+            { 'loading': 'spinner' }, 
+            { 'other': '.target' } ) }}>
         Hello
     </div>
 


### PR DESCRIPTION
In addition to missing the closing brace, it was hard to read because the copy button hovers over the text.   And since creating outlets is done with the 'other' key, it's particular important for that to be visible.