### PR TITLE
[Doc] Misc fixes

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ StimulusBundle: Symfony integration with Stimulus
 This bundle adds integration between Symfony, `Stimulus`_ and the Symfony UX packages:
 
 * Twig ``stimulus_`` functions & filters to add Stimulus controllers,
-   actions & targets in your templates;
+  actions & targets in your templates;
 * Integration to load :ref:`UX Packages <ux-packages>` (extra Stimulus controllers)
 
 Installation
@@ -100,33 +100,7 @@ common problems. StimulusBundle activates any 3rd party Stimulus controllers
 that are mentioned in your ``assets/controllers.json`` file. This file is updated
 whenever you install a UX package.
 
-The official UX packages are:
-
-* `ux-autocomplete`_: Transform ``EntityType``, ``ChoiceType`` or *any*
-  ``<select>`` element into an Ajax-powered autocomplete field
-  (`see demo <https://ux.symfony.com/autocomplete>`_)
-* `ux-chartjs`_: Easy charts with `Chart.js`_ (`see demo <https://ux.symfony.com/chartjs>`_)
-* `ux-cropperjs`_: Form Type and tools for cropping images (`see demo <https://ux.symfony.com/cropperjs>`_)
-* `ux-dropzone`_: Form Type for stylized "drop zone" for file uploads
-  (`see demo <https://ux.symfony.com/dropzone>`_)
-* `ux-lazy-image`_: Optimize Image Loading with BlurHash
-  (`see demo <https://ux.symfony.com/lazy-image>`_)
-* `ux-live-component`_: Build Dynamic Interfaces with Zero JavaScript
-  (`see demo <https://ux.symfony.com/live-component>`_)
-* `ux-notify`_: Send server-sent native notification with Mercure
-  (`see demo <https://ux.symfony.com/notify>`_)
-* `ux-react`_: Render `React`_ component from Twig (`see demo <https://ux.symfony.com/react>`_)
-* `ux-svelte`_: Render `Svelte`_ component from Twig (`see demo <https://ux.symfony.com/svelte>`_)
-* `ux-swup`_: Integration with `Swup`_ (`see demo <https://ux.symfony.com/swup>`_)
-* `ux-toggle-password`_: Toggle visibility of password inputs
-  (`see demo <https://ux.symfony.com/toggle-password>`_)
-* `ux-translator`_: Use your Symfony translations in JavaScript (`see demo <https://ux.symfony.com/translator>`_)
-* `ux-turbo`_: Integration with `Turbo Drive`_ for a single-page-app experience
-  (`see demo <https://ux.symfony.com/turbo>`_)
-* `ux-twig-component`_: Build Twig Components Backed by a PHP Class
-  (`see demo <https://ux.symfony.com/twig-component>`_)
-* `ux-typed`_: Integration with `Typed`_ (`see demo <https://ux.symfony.com/typed>`_)
-* `ux-vue`_: Render `Vue`_ component from Twig (`see demo <https://ux.symfony.com/vue>`_)
+Check out the `official UX packages`_.
 
 Lazy Stimulus Controllers
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -158,7 +132,7 @@ To make a third-party controller lazy, in ``assets/controllers.json``, set
 .. note::
 
     If you write your controllers using TypeScript and you're using
-    StimulusBundle ≤ 2.21.0, make sure ``removeComments`` is not set
+    StimulusBundle 2.21.0 or earlier, make sure ``removeComments`` is not set
     to ``true`` in your TypeScript config.
 
 Stimulus Tools around the World
@@ -550,31 +524,9 @@ it will normalize it:
 .. _`parameters`: https://stimulus.hotwired.dev/reference/actions#action-parameters
 .. _`Stimulus Targets`: https://stimulus.hotwired.dev/reference/targets
 .. _`StimulusBundle Flex recipe`: https://github.com/symfony/recipes/tree/main/symfony/stimulus-bundle
-.. _`ux-autocomplete`: https://symfony.com/bundles/ux-autocomplete/current/index.html
-.. _`ux-chartjs`: https://symfony.com/bundles/ux-chartjs/current/index.html
-.. _`ux-cropperjs`: https://symfony.com/bundles/ux-cropperjs/current/index.html
-.. _`ux-dropzone`: https://symfony.com/bundles/ux-dropzone/current/index.html
-.. _`ux-lazy-image`: https://symfony.com/bundles/ux-lazy-image/current/index.html
-.. _`ux-live-component`: https://symfony.com/bundles/ux-live-component/current/index.html
-.. _`ux-notify`: https://symfony.com/bundles/ux-notify/current/index.html
-.. _`ux-react`: https://symfony.com/bundles/ux-react/current/index.html
-.. _ux-translator: https://symfony.com/bundles/ux-translator/current/index.html
-.. _`ux-swup`: https://symfony.com/bundles/ux-swup/current/index.html
-.. _`ux-toggle-password`: https://symfony.com/bundles/ux-toggle-password/current/index.html
-.. _`ux-turbo`: https://symfony.com/bundles/ux-turbo/current/index.html
-.. _`ux-twig-component`: https://symfony.com/bundles/ux-twig-component/current/index.html
-.. _`ux-typed`: https://symfony.com/bundles/ux-typed/current/index.html
-.. _`ux-vue`: https://symfony.com/bundles/ux-vue/current/index.html
-.. _`ux-svelte`: https://symfony.com/bundles/ux-svelte/current/index.html
-.. _`Chart.js`: https://www.chartjs.org/
-.. _`Swup`: https://swup.js.org/
-.. _`React`: https://reactjs.org/
-.. _`Svelte`: https://svelte.dev/
-.. _`Turbo Drive`: https://turbo.hotwired.dev/
-.. _`Typed`: https://github.com/mattboldt/typed.js/
-.. _`Vue`: https://vuejs.org/
 .. _`stimulus-use`: https://stimulus-use.github.io/stimulus-use
 .. _`stimulus-components`: https://www.stimulus-components.com/
 .. _`TypeScript`: https://www.typescriptlang.org/
 .. _`sensiolabs/typescript-bundle`: https://github.com/sensiolabs/AssetMapperTypeScriptBundle
 .. _`Stimulus plugin`: https://plugins.jetbrains.com/plugin/24562-stimulus
+.. _`official UX packages`: https://ux.symfony.com/packages


### PR DESCRIPTION
This PR is mostly to fix this minor syntax issue in the doc intro:

<img width="853" alt="" src="https://github.com/user-attachments/assets/47b7e7aa-60fb-4053-af7b-8a911d19f83c" />

But, I also propose to remove the list of UX packages because this is very hard to maintain. For example, we're missing a lot of the packages added recently. So, I think it's better to just add a link to the always up-to-date listing on the website.
